### PR TITLE
Fix pt frl

### DIFF
--- a/daq2Control/config_fragments/RU/evb/RU_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application.xml
@@ -6,7 +6,6 @@
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
 		<numberOfResponders xsi:type="xsd:unsignedInt">3</numberOfResponders>
-		<maxTriggerRate xsi:type="xsd:unsignedInt">0</maxTriggerRate>
 		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">128</fragmentFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>

--- a/daq2Control/config_fragments/RU/evb/RU_context.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_context.xml
@@ -16,24 +16,17 @@
 			<useUdaplPool xsi:type="xsd:boolean">true</useUdaplPool>
 			<autoConnect xsi:type="xsd:boolean">false</autoConnect>
 			<!-- Copy worker configuration -->
-			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">65536</i2oFragmentBlockSize>
-			<i2oFragmentsNo xsi:type="xsd:unsignedInt">128</i2oFragmentsNo>
+			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">131072</i2oFragmentBlockSize>
+			<i2oFragmentsNo xsi:type="xsd:unsignedInt">64</i2oFragmentsNo>
 			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">10000000</i2oFragmentPoolSize>
 			<copyWorkerQueueSize xsi:type="xsd:unsignedInt">16</copyWorkerQueueSize>
 			<copyWorkersNo xsi:type="xsd:unsignedInt">4</copyWorkersNo>
-			<!-- Super fragment configuration -->
 			<doSuperFragment xsi:type="xsd:boolean">false</doSuperFragment>
-			<superFragmentWorkersNo xsi:type="xsd:unsignedInt">1</superFragmentWorkersNo>
-			<superFragmentWorkerQueueSize xsi:type="xsd:unsignedLong">1024</superFragmentWorkerQueueSize>
-			<destinationClassName xsi:type="xsd:string">evb::EVM</destinationClassName>
-			<destinationClassInstance xsi:type="xsd:unsignedLong">0</destinationClassInstance>
-			<dropAtSuperFragmentWorker xsi:type="xsd:boolean">false</dropAtSuperFragmentWorker>
-			<dropAtSuperFragmentDelivery xsi:type="xsd:boolean">false</dropAtSuperFragmentDelivery>
 			<!-- Input configuration e.g. PSP -->
 			<inputStreamPoolSize xsi:type="xsd:double">1400000</inputStreamPoolSize>
-			<maxClients xsi:type="xsd:unsignedInt">20</maxClients>
+			<maxClients xsi:type="xsd:unsignedInt">64</maxClients>
 			<ioQueueSize xsi:type="xsd:unsignedInt">64</ioQueueSize>
-			<eventQueueSize xsi:type="xsd:unsignedInt">64</eventQueueSize>
+			<eventQueueSize xsi:type="xsd:unsignedInt">256</eventQueueSize>
 			<maxInputReceiveBuffers xsi:type="xsd:unsignedInt">8</maxInputReceiveBuffers>
 			<maxInputBlockSize xsi:type="xsd:unsignedInt">131072</maxInputBlockSize>
 		</properties>

--- a/daq2Control/config_fragments/RU/evb/RU_context.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_context.xml
@@ -17,8 +17,8 @@
 			<autoConnect xsi:type="xsd:boolean">false</autoConnect>
 			<!-- Copy worker configuration -->
 			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">131072</i2oFragmentBlockSize>
-			<i2oFragmentsNo xsi:type="xsd:unsignedInt">64</i2oFragmentsNo>
-			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">10000000</i2oFragmentPoolSize>
+			<i2oFragmentsNo xsi:type="xsd:unsignedInt">128</i2oFragmentsNo>
+			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">40000000</i2oFragmentPoolSize>
 			<copyWorkerQueueSize xsi:type="xsd:unsignedInt">16</copyWorkerQueueSize>
 			<copyWorkersNo xsi:type="xsd:unsignedInt">4</copyWorkersNo>
 			<doSuperFragment xsi:type="xsd:boolean">false</doSuperFragment>

--- a/daq2Control/daq2Configurator.py
+++ b/daq2Control/daq2Configurator.py
@@ -496,7 +496,7 @@ class daq2Configurator(object):
 			                  '60600')
 		## route every second one to port 60600 if there is only one
 		## stream per RU
-		if self.streams_per_ferol==1 and (frl.index+1)%2==0:
+		if frl.nstreams==1 and (frl.index+1)%2==0:
 			self.setPropertyInAppInContext(ferol, classname,
 				                  'TCP_DESTINATION_PORT_FED0', '60600')
 		try:
@@ -1029,5 +1029,3 @@ class daq2Configurator(object):
 		self.writeConfig(destination)
 		if self.verbose>0: print ' Wrote config to %s' % destination
 		if self.verbose>0: print 70*'-'
-
-


### PR DESCRIPTION
This pull request uses the most optimal pt::frl parameters found so far. It also patches the routing bug of FEROL streams: in case that there is only one active FEROL stream, all streams are routed to one port on the RU instead of alternating. It seems there are 2 parameters used for defining the number of streams in daq2Configurator: self.streams_per_ferol and frl.nstreams. Only the latter is set correctly. I fixed it the most straightforward way for the production settings, but this should be reviewed for all cases.
