### PR TITLE
Working

### DIFF
--- a/2014-11-03-ru-network.csv
+++ b/2014-11-03-ru-network.csv
@@ -14,15 +14,15 @@ sw-eth-c2e23-20-01;TK TEC+,crate S1C11b,FEROL 13,FEDs 280,312,frlpc-s1d06-25-01
 sw-eth-c2e23-20-01;TK TEC+,crate S1C11b,FEROL 14,FEDs 281,313,frlpc-s1d06-25-01
 sw-eth-c2e23-20-01;TK TEC+,crate S1C11b,FEROL 15,FEDs 282,314,frlpc-s1d06-25-01
 sw-eth-c2e23-20-01;TK TEC+,crate S1C11b,FEROL 16,FEDs 283,315,frlpc-s1d06-25-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 1,FED 606,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 2,FED 607,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 3,FED 608,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 4,FED 609,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 5,FED 601,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 6,FED 602,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 7,FED 603,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 8,FED 604,frlpc-s2d10-09-01
-# sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 9,FED 605,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 1,FED 606,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 2,FED 607,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 3,FED 608,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 4,FED 609,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 5,FED 601,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 6,FED 602,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 7,FED 603,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 8,FED 604,frlpc-s2d10-09-01
+sw-eth-c2e23-20-01;ECAL E-,crate S2C02a,FEROL 9,FED 605,frlpc-s2d10-09-01
 sw-eth-c2e23-20-01;TOTEM,crate S2B05b,FEROL 1,frlpc-s2d10-21-01
 sw-eth-c2e23-20-01;TOTEM,crate S2B05b,FEROL 2,frlpc-s2d10-21-01
 sw-eth-c2e23-20-01;TOTEM,crate S2B05b,FEROL 3,frlpc-s2d10-21-01
@@ -58,15 +58,15 @@ sw-eth-c2e23-23-01;TK TEC-,crate S1B11b,FEROL 13,FEDs 232,256,frlpc-s1d06-10-01
 sw-eth-c2e23-23-01;TK TEC-,crate S1B11b,FEROL 14,FEDs 233,257,frlpc-s1d06-10-01
 sw-eth-c2e23-23-01;TK TEC-,crate S1B11b,FEROL 15,FEDs 234,258,frlpc-s1d06-10-01
 sw-eth-c2e23-23-01;TK TEC-,crate S1B11b,FEROL 16,FEDs 235,259,frlpc-s1d06-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 1,FED 628,frlpc-s2d10-10-01 ## conflict
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 2,FED 629,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 3,FED 630,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 4,FED 634,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 5,FED 635,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 6,FED 636,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 7,FED 631,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 8,FED 632,frlpc-s2d10-10-01
-# sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 9,FED 633,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 1,FED 628,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 2,FED 629,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 3,FED 630,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 4,FED 634,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 5,FED 635,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 6,FED 636,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 7,FED 631,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 8,FED 632,frlpc-s2d10-10-01
+sw-eth-c2e23-23-01;ECAL B+,crate S2C02b,FEROL 9,FED 633,frlpc-s2d10-10-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 1,frlpc-s2d10-22-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 2,frlpc-s2d10-22-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 3,frlpc-s2d10-22-01
@@ -79,12 +79,12 @@ sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 9,frlpc-s2d10-22-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 10,frlpc-s2d10-22-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 11,frlpc-s2d10-22-01
 sw-eth-c2e23-23-01;TOTEM,crate S2B05c,FEROL 12,frlpc-s2d10-22-01
-# sw-eth-c2e23-23-01;DTTF/CSCTF,crate S1C01a,FEROL 1,FED 780,frlpc-s1d06-11-01 ## conflict?
-# sw-eth-c2e23-23-01;DTTF/CSCTF,crate S1C01a,FEROL 2,FED 760,frlpc-s1d06-11-01
+sw-eth-c2e23-23-01;DTTF/CSCTF,crate S1C01a,FEROL 1,FED 780,frlpc-s1d06-11-01
+sw-eth-c2e23-23-01;DTTF/CSCTF,crate S1C01a,FEROL 2,FED 760,frlpc-s1d06-11-01
 # sw-eth-c2e23-23-01;DTTF/CSCTF,crate S1C01a,FEROL 3,FED -1,frlpc-s1d06-11-01
 sw-eth-c2e23-23-01;ru-c2e12-13-01
 sw-eth-c2e23-23-01;ru-c2e12-14-01
-# sw-eth-c2e23-23-01;ru-c2e12-15-01 ## conflict?
+sw-eth-c2e23-23-01;ru-c2e12-15-01
 sw-eth-c2e23-23-01;ru-c2e14-13-01
 sw-eth-c2e23-23-01;ru-c2e14-14-01
 sw-eth-c2e23-23-01;ru-c2e14-15-01
@@ -96,15 +96,15 @@ sw-eth-c2e23-26-01;Pix EC,crate S1G05b,FEROL 5,FED 36,frlpc-s1d06-31-01
 sw-eth-c2e23-26-01;Pix EC,crate S1G05b,FEROL 6,FED 37,frlpc-s1d06-31-01
 sw-eth-c2e23-26-01;Pix EC,crate S1G05b,FEROL 7,FED 38,frlpc-s1d06-31-01
 sw-eth-c2e23-26-01;Pix EC,crate S1G05b,FEROL 8,FED 39,frlpc-s1d06-31-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 1,FED 610,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 2,FED 611,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 3,FED 612,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 4,FED 616,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 5,FED 617,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 6,FED 618,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 7,FED 613,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 8,FED 614,frlpc-s2d10-11-01
-# sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 9,FED 615,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 1,FED 610,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 2,FED 611,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 3,FED 612,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 4,FED 616,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 5,FED 617,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 6,FED 618,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 7,FED 613,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 8,FED 614,frlpc-s2d10-11-01
+sw-eth-c2e23-26-01;ECAL B-,crate S2C02c,FEROL 9,FED 615,frlpc-s2d10-11-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 1,frlpc-s1d06-35-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 2,frlpc-s1d06-35-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 3,frlpc-s1d06-35-01
@@ -113,35 +113,35 @@ sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 5,frlpc-s1d06-35-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 6,frlpc-s1d06-35-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 7,frlpc-s1d06-35-01
 sw-eth-c2e23-26-01;MUON TRIG,crate S1C11c,FEROL 8,frlpc-s1d06-35-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 1,FED 546,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 2,FED 531,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 3,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 4,FED 547,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 5,FEDs 524,537,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 6,FEDs 532,539,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 7,FEDs 525,545,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 8,FED 540,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 9,FEDs 523,534,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 10,FEDs 522,541,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 11,FEDs 528,542,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 12,FED 520,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 13,FEDs 529,535,frlpc-s1d06-13-01
-# sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 14,FED 530,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 1,FED 546,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 2,FED 531,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 3,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 4,FED 547,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 5,FEDs 524,537,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 6,FEDs 532,539,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 7,FEDs 525,545,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 8,FED 540,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 9,FEDs 523,534,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 10,FEDs 522,541,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 11,FEDs 528,542,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 12,FED 520,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 13,FEDs 529,535,frlpc-s1d06-13-01
+sw-eth-c2e23-26-01;ES-,crate S1C01b,FEROL 14,FED 530,frlpc-s1d06-13-01
 sw-eth-c2e23-26-01;ru-c2e12-16-01
 sw-eth-c2e23-26-01;ru-c2e12-17-01
 sw-eth-c2e23-26-01;ru-c2e12-18-01
 sw-eth-c2e23-26-01;ru-c2e14-16-01
 sw-eth-c2e23-26-01;ru-c2e14-17-01
 sw-eth-c2e23-26-01;ru-c2e14-18-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 1,FED 648,frlpc-s2d10-17-01 ## conflict?
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 2,FED 649,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 3,FED 650,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 4,FED 654,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 5,FED 646,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 6,FED 647,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 7,FED 651,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 8,FED 652,frlpc-s2d10-17-01
-# sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 9,FED 653,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 1,FED 648,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 2,FED 649,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 3,FED 650,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 4,FED 654,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 5,FED 646,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 6,FED 647,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 7,FED 651,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 8,FED 652,frlpc-s2d10-17-01
+sw-eth-c2e23-29-01;ECAL E+,crate S2D09a,FEROL 9,FED 653,frlpc-s2d10-17-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 1,frlpc-s2d10-25-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 2,frlpc-s2d10-25-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 3,frlpc-s2d10-25-01
@@ -150,17 +150,17 @@ sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 5,frlpc-s2d10-25-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 6,frlpc-s2d10-25-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 7,frlpc-s2d10-25-01
 sw-eth-c2e23-29-01;ECAL TRIG,crate S2D09d,FEROL 8,frlpc-s2d10-25-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 2,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 3,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 4,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 5,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 6,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 7,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 8,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 9,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DTTF,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
-# sw-eth-c2e23-29-01;DTTF,crate S1F09e,FEROL 2,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 2,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 3,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 4,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 5,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 6,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 7,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 8,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DT,crate S1F09e,FEROL 9,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DTTF,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
+sw-eth-c2e23-29-01;DTTF,crate S1F09e,FEROL 2,frlpc-s1d06-36-01
 sw-eth-c2e23-29-01;PIXEL,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
 sw-eth-c2e23-29-01;PIXEL,crate S1F09e,FEROL 2,frlpc-s1d06-36-01
 sw-eth-c2e23-29-01;GT,crate S1F09e,FEROL 1,frlpc-s1d06-36-01
@@ -201,15 +201,15 @@ sw-eth-c2e23-32-01;TK TEC-,crate S1B07b,FEROL 13,FEDs 183,184,frlpc-s1d06-08-01
 sw-eth-c2e23-32-01;TK TEC-,crate S1B07b,FEROL 14,FEDs 185,186,frlpc-s1d06-08-01
 sw-eth-c2e23-32-01;TK TEC-,crate S1B07b,FEROL 15,FEDs 187,188,frlpc-s1d06-08-01
 sw-eth-c2e23-32-01;TK TEC-,crate S1B07b,FEROL 16,FEDs 164,165,frlpc-s1d06-08-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 1,FED 643,frlpc-s2d10-18-01 ## conflict?
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 2,FED 644,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 3,FED 645,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 4,FED 637,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 5,FED 638,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 6,FED 639,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 7,FED 640,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 8,FED 641,frlpc-s2d10-18-01
-# sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 9,FED 642,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 1,FED 643,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 2,FED 644,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 3,FED 645,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 4,FED 637,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 5,FED 638,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 6,FED 639,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 7,FED 640,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 8,FED 641,frlpc-s2d10-18-01
+sw-eth-c2e23-32-01;ECAL B+,crate S2D09b,FEROL 9,FED 642,frlpc-s2d10-18-01
 # sw-eth-c2e23-32-01;TCDS 1,crate S1C01d,FEROL 1,FED 1026,frlpc-s1d06-15-01 ## conflict?
 # sw-eth-c2e23-32-01;TCDS 1,crate S1C01d,FEROL 2,FED 1027,frlpc-s1d06-15-01
 # sw-eth-c2e23-32-01;TCDS 1,crate S1C01d,FEROL 3,FED 1028,frlpc-s1d06-15-01
@@ -231,45 +231,45 @@ sw-eth-c2e23-32-01;ru-c2e12-26-01
 sw-eth-c2e23-32-01;ru-c2e14-24-01
 sw-eth-c2e23-32-01;ru-c2e14-25-01
 sw-eth-c2e23-32-01;ru-c2e14-26-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 1,FEDs 166,204,frlpc-s1d06-09-01 ## conflict?
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 2,FEDs 167,205,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 3,FEDs 168,206,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 4,FEDs 169,207,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 5,FEDs 170,208,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 6,FEDs 171,209,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 7,FEDs 172,210,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 8,FEDs 173,211,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 9,FEDs 212,236,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 10,FEDs 213,237,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 11,FEDs 214,238,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 12,FEDs 215,239,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 13,FEDs 216,240,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 14,FEDs 217,241,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 15,FEDs 218,242,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 16,FEDs 219,243,frlpc-s1d06-09-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 1,FED 625,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 2,FED 626,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 3,FED 627,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 4,FED 619,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 5,FED 620,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 6,FED 621,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 7,FED 622,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 8,FED 623,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 9,FED 624,frlpc-s2d10-20-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 1,FEDs 557,571,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 2,FEDs 555,569,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 3,FED 563,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 4,FED 549,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 5,FEDs 551,570,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 6,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 7,FEDs 556,575,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 8,FEDs 548,564,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 9,FED 568,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 10,FEDs 554,572,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 11,FEDs 560,574,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 12,FED 566,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 13,FEDs 553,573,frlpc-s1d06-14-01
-# sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 14,FEDs 561,565,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 1,FEDs 166,204,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 2,FEDs 167,205,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 3,FEDs 168,206,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 4,FEDs 169,207,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 5,FEDs 170,208,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 6,FEDs 171,209,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 7,FEDs 172,210,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 8,FEDs 173,211,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 9,FEDs 212,236,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 10,FEDs 213,237,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 11,FEDs 214,238,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 12,FEDs 215,239,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 13,FEDs 216,240,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 14,FEDs 217,241,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 15,FEDs 218,242,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;TK TEC-,crate S1B07c,FEROL 16,FEDs 219,243,frlpc-s1d06-09-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 1,FED 625,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 2,FED 626,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 3,FED 627,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 4,FED 619,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 5,FED 620,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 6,FED 621,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 7,FED 622,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 8,FED 623,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ECAL B-,crate S2D09c,FEROL 9,FED 624,frlpc-s2d10-20-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 1,FEDs 557,571,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 2,FEDs 555,569,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 3,FED 563,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 4,FED 549,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 5,FEDs 551,570,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 6,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 7,FEDs 556,575,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 8,FEDs 548,564,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 9,FED 568,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 10,FEDs 554,572,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 11,FEDs 560,574,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 12,FED 566,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 13,FEDs 553,573,frlpc-s1d06-14-01
+sw-eth-c2e23-35-01;ES+,crate S1C01c,FEROL 14,FEDs 561,565,frlpc-s1d06-14-01
 sw-eth-c2e23-35-01;ru-c2e12-27-01
 sw-eth-c2e23-35-01;ru-c2e12-28-01
 sw-eth-c2e23-35-01;ru-c2e12-29-01
@@ -291,12 +291,12 @@ sw-eth-c2e23-38-01;TK TID,crate S1B06b,FEROL 12,FED 160,frlpc-s1d06-04-01
 sw-eth-c2e23-38-01;TK TID,crate S1B06b,FEROL 13,FED 161,frlpc-s1d06-04-01
 sw-eth-c2e23-38-01;TK TID,crate S1B06b,FEROL 14,FED 162,frlpc-s1d06-04-01
 sw-eth-c2e23-38-01;TK TID,crate S1B06b,FEROL 15,FED 163,frlpc-s1d06-04-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 1,FED 706,frlpc-s2d10-13-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 2,FED 707,frlpc-s2d10-13-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 3,FED 708,frlpc-s2d10-13-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 4,FED 709,frlpc-s2d10-13-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 5,FED 710,frlpc-s2d10-13-01
-# sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 6,FED 711,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 1,FED 706,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 2,FED 707,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 3,FED 708,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 4,FED 709,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 5,FED 710,frlpc-s2d10-13-01
+sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 6,FED 711,frlpc-s2d10-13-01
 # sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 7,FED 705,frlpc-s2d10-13-01 ## no card?
 # sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 8,FED 704,frlpc-s2d10-13-01 ## no card?
 # sw-eth-c2e23-38-01;HCAL B/E,crate S2F10a,FEROL 9,FED 702,frlpc-s2d10-13-01
@@ -358,12 +358,12 @@ sw-eth-c2e24-20-01;TK TID,crate S1B06c,FEROL 12,FED 145,frlpc-s1d06-05-01
 sw-eth-c2e24-20-01;TK TID,crate S1B06c,FEROL 13,FED 146,frlpc-s1d06-05-01
 sw-eth-c2e24-20-01;TK TID,crate S1B06c,FEROL 14,FED 147,frlpc-s1d06-05-01
 sw-eth-c2e24-20-01;TK TID,crate S1B06c,FEROL 15,FED 148,frlpc-s1d06-05-01
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 1,FED 716,frlpc-s2d10-15-01 ## used by GT
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 2,FED 717,frlpc-s2d10-15-01
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 3,FED 714,frlpc-s2d10-15-01
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 4,FED 715,frlpc-s2d10-15-01
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 5,FED 713,frlpc-s2d10-15-01
-# sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 6,FED 712,frlpc-s2d10-15-01
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 1,FED 716,frlpc-s2d10-15-01 ## used by GT
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 2,FED 717,frlpc-s2d10-15-01
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 3,FED 714,frlpc-s2d10-15-01
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 4,FED 715,frlpc-s2d10-15-01
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 5,FED 713,frlpc-s2d10-15-01
+sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 6,FED 712,frlpc-s2d10-15-01
 # #sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 7,FED 718,frlpc-s2d10-15-01 ## no cards
 # #sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 8,FED 719,frlpc-s2d10-15-01
 # #sw-eth-c2e24-20-01;HCAL F+B/E,crate S2F10b,FEROL 9,FED 721,frlpc-s2d10-15-01
@@ -508,18 +508,18 @@ sw-eth-c2e24-29-01;HCAL HE/HB,crate S2F10e,FEROL 9
 sw-eth-c2e24-29-01;GCT/GT,crate S1F09b,FEROL 1,FED 745,frlpc-s1d06-27-01
 sw-eth-c2e24-29-01;GCT/GT,crate S1F09b,FEROL 2,FED 812,frlpc-s1d06-27-01
 # sw-eth-c2e24-29-01;GCT/GT,crate S1F09b,FEROL 3,FED 813,frlpc-s1d06-27-01 ## no card?
-# sw-eth-c2e24-29-01;ru-c2e13-19-01 ## conflict?
+sw-eth-c2e24-29-01;ru-c2e13-19-01
 sw-eth-c2e24-29-01;ru-c2e13-22-01
 sw-eth-c2e24-29-01;ru-c2e13-23-01
 sw-eth-c2e24-29-01;ru-c2e15-19-01
 sw-eth-c2e24-29-01;ru-c2e15-22-01
 sw-eth-c2e24-29-01;ru-c2e15-23-01
 # sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 1,FEDs 373,427,frlpc-s1d06-22-01 ## no cards
-# sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 2,FEDs 374,428,frlpc-s1d06-22-01
-# sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 3,FEDs 375,429,frlpc-s1d06-22-01
-# sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 4,FEDs 368,413,frlpc-s1d06-22-01
-# sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 5,FEDs 369,414,frlpc-s1d06-22-01
-# sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 6,FEDs 370,415,frlpc-s1d06-22-01
+sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 2,FEDs 374,428,frlpc-s1d06-22-01
+sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 3,FEDs 375,429,frlpc-s1d06-22-01
+sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 4,FEDs 368,413,frlpc-s1d06-22-01
+sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 5,FEDs 369,414,frlpc-s1d06-22-01
+sw-eth-c2e24-32-01;TK TOB,crate S1C06d,FEROL 6,FEDs 370,415,frlpc-s1d06-22-01
 sw-eth-c2e24-32-01;TK TIB,crate S1B02d,FEROL 1,FED 62,frlpc-s1d06-03-01
 sw-eth-c2e24-32-01;TK TIB,crate S1B02d,FEROL 2,FED 63,frlpc-s1d06-03-01
 sw-eth-c2e24-32-01;TK TIB,crate S1B02d,FEROL 3,FED 64,frlpc-s1d06-03-01
@@ -572,22 +572,22 @@ sw-eth-c2e24-35-01;TK TEC+,crate S1C07b,FEROL 13,FEDs 335,336,frlpc-s1d06-23-01
 sw-eth-c2e24-35-01;TK TEC+,crate S1C07b,FEROL 14,FEDs 337,338,frlpc-s1d06-23-01
 sw-eth-c2e24-35-01;TK TEC+,crate S1C07b,FEROL 15,FEDs 339,340,frlpc-s1d06-23-01
 sw-eth-c2e24-35-01;TK TEC+,crate S1C07b,FEROL 16,FEDs 316,317,frlpc-s1d06-23-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 1,FED 31,frlpc-s1d06-32-01 ## sysadmins
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 2,FED 30,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 3,FED 29,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 4,FED 28,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 5,FED 27,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 6,FED 26,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 7,FED 25,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 8,FED 24,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 9,FED 23,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 10,FED 22,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 11,FED 21,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 12,FED 20,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 13,FED 19,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 14,FED 18,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 15,FED 17,frlpc-s1d06-32-01
-# sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 16,FED 16,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 1,FED 31,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 2,FED 30,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 3,FED 29,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 4,FED 28,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 5,FED 27,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 6,FED 26,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 7,FED 25,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 8,FED 24,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 9,FED 23,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 10,FED 22,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 11,FED 21,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 12,FED 20,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 13,FED 19,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 14,FED 18,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 15,FED 17,frlpc-s1d06-32-01
+sw-eth-c2e24-35-01;Pix BA,crate S1G05c,FEROL 16,FED 16,frlpc-s1d06-32-01
 # sw-eth-c2e24-35-01;DT,crate S1G05a,FEROL 1,FED 770,frlpc-s1d06-30-01
 # sw-eth-c2e24-35-01;DT,crate S1G05a,FEROL 2,FED 771,frlpc-s1d06-30-01
 # sw-eth-c2e24-35-01;DT,crate S1G05a,FEROL 3,FED 772,frlpc-s1d06-30-01
@@ -620,22 +620,22 @@ sw-eth-c2e24-38-01;TK TEC+,crate S1C07c,FEROL 13,FEDs 264,296,frlpc-s1d06-24-01
 sw-eth-c2e24-38-01;TK TEC+,crate S1C07c,FEROL 14,FEDs 265,297,frlpc-s1d06-24-01
 sw-eth-c2e24-38-01;TK TEC+,crate S1C07c,FEROL 15,FEDs 266,298,frlpc-s1d06-24-01
 sw-eth-c2e24-38-01;TK TEC+,crate S1C07c,FEROL 16,FEDs 267,299,frlpc-s1d06-24-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 1,FED 15,frlpc-s1d06-33-01 ## sysadmins
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 2,FED 14,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 3,FED 13,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 4,FED 12,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 5,FED 11,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 6,FED 10,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 7,FED 9,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 8,FED 8,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 9,FED 7,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 10,FED 6,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 11,FED 5,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 12,FED 4,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 13,FED 3,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 14,FED 2,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 15,FED 1,frlpc-s1d06-33-01
-# sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 16,FED 0,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 1,FED 15,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 2,FED 14,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 3,FED 13,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 4,FED 12,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 5,FED 11,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 6,FED 10,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 7,FED 9,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 8,FED 8,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 9,FED 7,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 10,FED 6,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 11,FED 5,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 12,FED 4,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 13,FED 3,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 14,FED 2,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 15,FED 1,frlpc-s1d06-33-01
+sw-eth-c2e24-38-01;Pix BA,crate S1G05d,FEROL 16,FED 0,frlpc-s1d06-33-01
 sw-eth-c2e24-38-01;LTC,crate S1F09c,FEROL 1,FED 816,frlpc-s1d06-37-01
 sw-eth-c2e24-38-01;LTC,crate S1F09c,FEROL 2,FED 817,frlpc-s1d06-37-01
 sw-eth-c2e24-38-01;LTC,crate S1F09c,FEROL 3,FED 820,frlpc-s1d06-37-01

--- a/daq2Control/config_fragments/BU/BU_ibv_application.xml
+++ b/daq2Control/config_fragments/BU/BU_ibv_application.xml
@@ -1,16 +1,16 @@
 <xc:Application class="pt::ibv::Application" id="21" instance="0" network="infini" xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<properties xmlns="urn:xdaq-application:pt::ibv::Application" xsi:type="soapenc:Struct">
-		<senderPoolSize xsi:type="xsd:unsignedLong">0x4000000</senderPoolSize>
-		<receiverPoolSize xsi:type="xsd:unsignedLong">0x40000000</receiverPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">1024</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">1024</sendQueuePairSize>
+		<senderPoolSize xsi:type="xsd:unsignedLong">0x100000</senderPoolSize>
+		<receiverPoolSize xsi:type="xsd:unsignedLong">0x100000000</receiverPoolSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">32</sendQueuePairSize>
 		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
 		<iaName xsi:type="xsd:string">mlx4_0</iaName>
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
-		<sendWithTimeout xsi:type="xsd:boolean">false</sendWithTimeout>
+		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">true</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/BU/BU_ibv_application.xml
+++ b/daq2Control/config_fragments/BU/BU_ibv_application.xml
@@ -1,16 +1,16 @@
 <xc:Application class="pt::ibv::Application" id="21" instance="0" network="infini" xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<properties xmlns="urn:xdaq-application:pt::ibv::Application" xsi:type="soapenc:Struct">
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x100000</senderPoolSize>
-		<receiverPoolSize xsi:type="xsd:unsignedLong">0x100000000</receiverPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">32</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
+		<receiverPoolSize xsi:type="xsd:unsignedLong">0x200000000</receiverPoolSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">256</sendQueuePairSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">1024</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
 		<iaName xsi:type="xsd:string">mlx4_0</iaName>
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
-		<useRelay xsi:type="xsd:boolean">true</useRelay>
+		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/BU/evb/BU_application.xml
+++ b/daq2Control/config_fragments/BU/evb/BU_application.xml
@@ -1,10 +1,10 @@
 <xc:Application class="evb::BU" id="43" instance="0" network="infini" xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<properties xmlns="urn:xdaq-application:evb::BU" xsi:type="soapenc:Struct">
 		<dropEventData xsi:type="xsd:boolean">true</dropEventData>
-		<maxEvtsUnderConstruction xsi:type="xsd:unsignedInt">512</maxEvtsUnderConstruction>
-		<eventsPerRequest xsi:type="xsd:unsignedInt">32</eventsPerRequest>
+		<maxEvtsUnderConstruction xsi:type="xsd:unsignedInt">640</maxEvtsUnderConstruction>
+		<eventsPerRequest xsi:type="xsd:unsignedInt">64</eventsPerRequest>
 		<lumiSectionTimeout xsi:type="xsd:unsignedInt">0</lumiSectionTimeout>
-		<numberOfBuilders xsi:type="xsd:unsignedInt">6</numberOfBuilders>
+		<numberOfBuilders xsi:type="xsd:unsignedInt">5</numberOfBuilders>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/BU/evb/BU_application.xml
+++ b/daq2Control/config_fragments/BU/evb/BU_application.xml
@@ -1,7 +1,7 @@
 <xc:Application class="evb::BU" id="43" instance="0" network="infini" xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<properties xmlns="urn:xdaq-application:evb::BU" xsi:type="soapenc:Struct">
 		<dropEventData xsi:type="xsd:boolean">true</dropEventData>
-		<maxEvtsUnderConstruction xsi:type="xsd:unsignedInt">288</maxEvtsUnderConstruction>
+		<maxEvtsUnderConstruction xsi:type="xsd:unsignedInt">512</maxEvtsUnderConstruction>
 		<eventsPerRequest xsi:type="xsd:unsignedInt">32</eventsPerRequest>
 		<lumiSectionTimeout xsi:type="xsd:unsignedInt">0</lumiSectionTimeout>
 		<numberOfBuilders xsi:type="xsd:unsignedInt">6</numberOfBuilders>

--- a/daq2Control/config_fragments/BU/evb/BU_policy_ibv.xml
+++ b/daq2Control/config_fragments/BU/evb/BU_policy_ibv.xml
@@ -1,13 +1,12 @@
 <pol:policy xmlns:pol="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor-(.+)/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
 	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="10" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="12" />
+	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="10" />
+	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="12" />
 	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="8" />
-	<pol:element pattern="urn:toolbox-mem-allocator-ibv-receiver-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+	<pol:element pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
 	<pol:element pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
 	<pol:element pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:http-(.+)/waiting" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
 	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_0/waiting" type="thread" package="numa" mempolicy="local" affinity="9" />
 	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_1/waiting" type="thread" package="numa" mempolicy="local" affinity="14" />
 	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_2/waiting" type="thread" package="numa" mempolicy="local" affinity="15" />
@@ -19,7 +18,7 @@
 	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/lumiAccounting/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
 	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
 	<pol:element pattern="urn:superFragmentFIFO(.+)" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:lumiSectionAccountFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+	<pol:element pattern="urn:fileStatisticsFIFO_stream(.+):alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
 	<pol:element pattern="urn:freeResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
 	<pol:element pattern="urn:blockedResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
 </pol:policy>

--- a/daq2Control/config_fragments/RU/evb/RU_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application.xml
@@ -5,9 +5,9 @@
 		<blockSize xsi:type="xsd:unsignedInt">131072</blockSize>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
-		<numberOfResponders xsi:type="xsd:unsignedInt">3</numberOfResponders>
-		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">128</fragmentFIFOCapacity>
-                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1024</fragmentRequestFIFOCapacity>
+		<numberOfResponders xsi:type="xsd:unsignedInt">4</numberOfResponders>
+		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">512</fragmentFIFOCapacity>
+                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">640</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application.xml
@@ -2,11 +2,12 @@
 	<properties xmlns="urn:xdaq-application:evb::RU" xsi:type="soapenc:Struct">
 		<inputSource xsi:type="xsd:string">FEROL</inputSource>
 		<dropInputData xsi:type="xsd:boolean">false</dropInputData>
-		<blockSize xsi:type="xsd:unsignedInt">130000</blockSize>
+		<blockSize xsi:type="xsd:unsignedInt">131072</blockSize>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
 		<numberOfResponders xsi:type="xsd:unsignedInt">3</numberOfResponders>
 		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">128</fragmentFIFOCapacity>
+                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1024</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
@@ -2,12 +2,13 @@
 	<properties xmlns="urn:xdaq-application:evb::EVM" xsi:type="soapenc:Struct">
 		<inputSource xsi:type="xsd:string">FEROL</inputSource>
 		<dropInputData xsi:type="xsd:boolean">false</dropInputData>
-		<blockSize xsi:type="xsd:unsignedInt">130000</blockSize>
+		<blockSize xsi:type="xsd:unsignedInt">16384</blockSize>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
 		<numberOfResponders xsi:type="xsd:unsignedInt">3</numberOfResponders>
 		<maxTriggerRate xsi:type="xsd:unsignedInt">0</maxTriggerRate>
 		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">128</fragmentFIFOCapacity>
+                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1024</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
@@ -2,13 +2,14 @@
 	<properties xmlns="urn:xdaq-application:evb::EVM" xsi:type="soapenc:Struct">
 		<inputSource xsi:type="xsd:string">FEROL</inputSource>
 		<dropInputData xsi:type="xsd:boolean">false</dropInputData>
-		<blockSize xsi:type="xsd:unsignedInt">16384</blockSize>
+		<blockSize xsi:type="xsd:unsignedInt">8192</blockSize>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
-		<numberOfResponders xsi:type="xsd:unsignedInt">3</numberOfResponders>
+		<numberOfResponders xsi:type="xsd:unsignedInt">2</numberOfResponders>
+		<numberOfAllocators xsi:type="xsd:unsignedInt">2</numberOfAllocators>
 		<maxTriggerRate xsi:type="xsd:unsignedInt">0</maxTriggerRate>
-		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">128</fragmentFIFOCapacity>
-                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1024</fragmentRequestFIFOCapacity>
+		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">512</fragmentFIFOCapacity>
+                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">640</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_context.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_context.xml
@@ -16,19 +16,19 @@
 			<useUdaplPool xsi:type="xsd:boolean">true</useUdaplPool>
 			<autoConnect xsi:type="xsd:boolean">false</autoConnect>
 			<!-- Copy worker configuration -->
-			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">131072</i2oFragmentBlockSize>
-			<i2oFragmentsNo xsi:type="xsd:unsignedInt">128</i2oFragmentsNo>
-			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">40000000</i2oFragmentPoolSize>
+			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">262144</i2oFragmentBlockSize>
+			<i2oFragmentsNo xsi:type="xsd:unsignedInt">512</i2oFragmentsNo>
+			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">320000000</i2oFragmentPoolSize>
 			<copyWorkerQueueSize xsi:type="xsd:unsignedInt">16</copyWorkerQueueSize>
 			<copyWorkersNo xsi:type="xsd:unsignedInt">4</copyWorkersNo>
 			<doSuperFragment xsi:type="xsd:boolean">false</doSuperFragment>
 			<!-- Input configuration e.g. PSP -->
-			<inputStreamPoolSize xsi:type="xsd:double">1400000</inputStreamPoolSize>
+			<inputStreamPoolSize xsi:type="xsd:double">2800000</inputStreamPoolSize>
 			<maxClients xsi:type="xsd:unsignedInt">64</maxClients>
 			<ioQueueSize xsi:type="xsd:unsignedInt">64</ioQueueSize>
 			<eventQueueSize xsi:type="xsd:unsignedInt">256</eventQueueSize>
 			<maxInputReceiveBuffers xsi:type="xsd:unsignedInt">8</maxInputReceiveBuffers>
-			<maxInputBlockSize xsi:type="xsd:unsignedInt">131072</maxInputBlockSize>
+			<maxInputBlockSize xsi:type="xsd:unsignedInt">262144</maxInputBlockSize>
 		</properties>
 	</xc:Application>
 	<xc:Module>$XDAQ_ROOT/lib/libtcpla.so</xc:Module>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
@@ -3,14 +3,14 @@
 		<iaName xsi:type="xsd:string">mlx4_0</iaName>
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
-		<receiverPoolSize xsi:type="xsd:unsignedLong">0x40000000</receiverPoolSize>
+		<receiverPoolSize xsi:type="xsd:unsignedLong">0x4000000</receiverPoolSize>
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
 		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">8192</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">64</recvQueuePairSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">128</sendQueuePairSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
-		<sendWithTimeout xsi:type="xsd:boolean">false</sendWithTimeout>
+		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">true</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
@@ -5,12 +5,12 @@
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
 		<receiverPoolSize xsi:type="xsd:unsignedLong">0x4000000</receiverPoolSize>
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">128</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">512</sendQueuePairSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">256</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
-		<useRelay xsi:type="xsd:boolean">true</useRelay>
+		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
@@ -5,12 +5,12 @@
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
 		<receiverPoolSize xsi:type="xsd:unsignedLong">0x40000000</receiverPoolSize>
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">1024</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
-		<maxMessageSize xsi:type="xsd:unsignedInt">16384</maxMessageSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">256</sendQueuePairSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">256</recvQueuePairSize>
+		<maxMessageSize xsi:type="xsd:unsignedInt">8192</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
-		<useRelay xsi:type="xsd:boolean">true</useRelay>
+		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
@@ -3,14 +3,14 @@
 		<iaName xsi:type="xsd:string">mlx4_0</iaName>
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
-		<receiverPoolSize xsi:type="xsd:unsignedLong">0x100000000</receiverPoolSize>
-		<senderPoolSize xsi:type="xsd:unsignedLong">0x280000000</senderPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">12800</completionQueueSize>
+		<receiverPoolSize xsi:type="xsd:unsignedLong">0x40000000</receiverPoolSize>
+		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">8192</completionQueueSize>
 		<sendQueuePairSize xsi:type="xsd:unsignedInt">1024</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">256</recvQueuePairSize>
-		<maxMessageSize xsi:type="xsd:unsignedInt">257000</maxMessageSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">128</recvQueuePairSize>
+		<maxMessageSize xsi:type="xsd:unsignedInt">16384</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
-		<sendWithTimeout xsi:type="xsd:boolean">false</sendWithTimeout>
+		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">true</useRelay>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/RU/evb/RU_policy_ibv.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_policy_ibv.xml
@@ -1,10 +1,10 @@
     <ns1:policy xmlns:ns1="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
-      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::acceptor/waiting" type="thread"/>
+      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread"/>
       <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" type="thread"/>
-      <ns1:element affinity="2" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr/polling" type="thread"/>
-      <ns1:element affinity="6" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops/polling" type="thread"/>
+      <ns1:element affinity="2" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread"/>
+      <ns1:element affinity="6" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread"/>
       <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:toolbox-mem-allocator-ibv-receiver-mlx4_0:ibvla" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc"/>
       <ns1:element affinity="0" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread"/>
       <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc"/>
       <ns1:element affinity="9" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:RU%d_FRL_PORT/polling" type="thread"/>
@@ -28,11 +28,8 @@
       <ns1:element affinity="20" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread"/>
       <ns1:element affinity="10" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread"/>
       <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread"/>
-      <ns1:element cpunodes="0" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/assignEvents/waiting" type="thread"/>
       <ns1:element cpunodes="0" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread"/>
       <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentFIFO_FED(.+)" type="alloc"/>
       <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentRequestFIFO:alloc" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:superFragmentFIFO:alloc" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:allocateFIFO:alloc" type="alloc"/>
       <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:undefined:alloc" type="alloc"/>
     </ns1:policy>

--- a/daq2Control/config_fragments/RU/evb/RU_policy_ibv_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_policy_ibv_EVM.xml
@@ -1,0 +1,39 @@
+    <ns1:policy xmlns:ns1="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
+      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread"/>
+      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" type="thread"/>
+      <ns1:element affinity="2" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread"/>
+      <ns1:element affinity="6" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc"/>
+      <ns1:element affinity="0" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread"/>
+      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc"/>
+      <ns1:element affinity="9" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:RU%d_FRL_PORT/polling" type="thread"/>
+      <ns1:element affinity="13" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:60600/polling" type="thread"/>
+      <ns1:element affinity="14" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-0" type="thread"/>
+      <ns1:element affinity="12" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-1" type="thread"/>
+      <ns1:element affinity="30" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-2" type="thread"/>
+      <ns1:element affinity="28" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-3" type="thread"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:tcpla-PublicServicePoint-rlist/RU%d_FRL_HOST_NAME" type="alloc"/>
+      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-acceptor-dispatcher(.+)" type="thread"/>
+      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-connector-dispatcher(.+)" type="thread"/>
+      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-ia(.+)" type="thread"/>
+      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-receiver-dispatcher(.+)" type="thread"/>
+      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-sender-dispatcher(.+)" type="thread"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-fragment" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-socket" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-CopyWorker-rlist" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-MemoryCache-rlist" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:squeue:alloc" type="alloc"/>
+      <ns1:element affinity="8" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_0/waiting" type="thread"/>
+      <ns1:element affinity="20" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread"/>
+      <ns1:element affinity="10" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread"/>
+      <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread"/>
+      <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_0/waiting" type="thread"/>
+      <ns1:element affinity="28" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_1/waiting" type="thread"/>
+      <ns1:element affinity="30" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_2/waiting" type="thread"/>
+      <ns1:element cpunodes="0" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentFIFO_FED(.+)" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentRequestFIFO:alloc" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:allocateFIFO(.+):alloc" type="alloc"/>
+      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:undefined:alloc" type="alloc"/>
+    </ns1:policy>

--- a/daq2Control/daq2Configurator.py
+++ b/daq2Control/daq2Configurator.py
@@ -770,9 +770,14 @@ class daq2Configurator(object):
 		ru_context = elementFromFile(self.fragmentdir+fragmentname)
 
 		## Add policy
-		addFragmentFromFile(target=ru_context, filename=self.fragmentdir+
-			                '/RU/%s/RU_policy_%s.xml'%
-			                (self.evbns,self.ptprot), index=0)
+		if isEVM:
+			addFragmentFromFile(target=ru_context, filename=self.fragmentdir+
+			                    '/RU/%s/RU_policy_%s_EVM.xml'%
+			                    (self.evbns,self.ptprot), index=0)
+		else:
+			addFragmentFromFile(target=ru_context, filename=self.fragmentdir+
+			                    '/RU/%s/RU_policy_%s.xml'%
+			                    (self.evbns,self.ptprot), index=0)
 		polns = "http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10"
 		for element in ru_context.findall(QN(polns,"policy").text+'/'+
 			                              QN(polns,"element").text):

--- a/daq2Control/daq2Utils.py
+++ b/daq2Control/daq2Utils.py
@@ -112,6 +112,16 @@ def testBuilding(d2c, minevents=1000, waittime=15, verbose=1, dry=False):
 	eventCounter = []
 	events = []
 	if not d2c.config.useMSIO:
+		if d2c.config.useEvB:
+			for n,ru in enumerate(d2c.config.RUs):
+				if n == 0:
+					namespace = d2c.config.namespace+'EVM'
+				else:
+					namespace = d2c.config.namespace+'RU'
+				nEvts = getParam(ru, namespace,
+					             'eventCount', 'xsd:unsignedLong',
+					             verbose=verbose, dry=dry)
+				events.append((ru.name, nEvts))
 		for n,bu in enumerate(d2c.config.BUs):
 			if d2c.config.useEvB:
 				nEvts = getParam(bu, d2c.config.namespace+'BU',

--- a/daq2Control/makeDAQ2ProdConfig.py
+++ b/daq2Control/makeDAQ2ProdConfig.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
 
 		allbus = daq2HWInfo.getAllBUs()
 		if opt.nBUs > len(allbus):
-			raise RuntimeError("Not enough BUs in inventory")
+			raise RuntimeError("Not enough BUs in inventory: only found "+str(len(allbus)))
 		for n,bu in enumerate(allbus):
 			if n == opt.nBUs: break
 			writeEntry(outfile, 'BU', bu, n)
@@ -156,7 +156,3 @@ if __name__ == "__main__":
 	print  70*'-'
 
 	exit(0)
-
-
-
-

--- a/daq2Control/runDAQ2Scan.py
+++ b/daq2Control/runDAQ2Scan.py
@@ -177,8 +177,7 @@ WARNING: Your maximum size for scanning doesn't seem to
 				d2c.retry('GTPe does not seem to be running, will stop and '
 					      'restart.')
 		## Also do a test when running with EvB/inputemulator:
-		if (d2c.config.useInputEmulator and
-			d2c.config.useEvB and
+		if (d2c.config.useEvB and
 			options.stopRestart):
 			if not testBuilding(d2c, minevents=100, waittime=10,
 				                verbose=0, dry=options.dry):
@@ -244,4 +243,3 @@ if __name__ == "__main__":
 		exit(-1)
 
 	exit(0)
-


### PR DESCRIPTION
Hi Benjamin,

these are the changes I made the previous week for the performance measurements of the EvB. They contain the "best" parameter settings I could come up with. For this, I had to split the EVM configurations snippets from the RU one. I just added corresponding files with _EVM. I'm not sure if this is the best/cleanest way to go.

There are also some more modifications to the scripts. I added an option --plotBU to plotData to plot the throughput on the BUs instead on the RUs. I also "fixed" the fragment size calculation to get the actual fragment size. However, I think this will not work for all test scenarios. Maybe it would be better to save the fragment size as being set on the FEROLs during the test instead of trying to recalculate it. Anyway, I don't want to mess too much with your code/logic.

Cheers,
Remi
