### PR TITLE
Separate evm

### DIFF
--- a/daq2Control/config_fragments/BU/BU_ibv_application.xml
+++ b/daq2Control/config_fragments/BU/BU_ibv_application.xml
@@ -1,15 +1,16 @@
 <xc:Application class="pt::ibv::Application" id="21" instance="0" network="infini" xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<properties xmlns="urn:xdaq-application:pt::ibv::Application" xsi:type="soapenc:Struct">
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x100000</senderPoolSize>
-		<receiverPoolSize xsi:type="xsd:unsignedLong">0x200000000</receiverPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">256</sendQueuePairSize>
-		<recvQueuePairSize xsi:type="xsd:unsignedInt">1024</recvQueuePairSize>
+		<receiverPoolSize xsi:type="xsd:unsignedLong">0x300000000</receiverPoolSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">32768</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">128</sendQueuePairSize>
+		<recvQueuePairSize xsi:type="xsd:unsignedInt">512</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
 		<iaName xsi:type="xsd:string">mlx4_0</iaName>
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
+		<memAllocTimeout xsi:type="xsd:string">PT1S</memAllocTimeout>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>

--- a/daq2Control/config_fragments/BU/evb/BU_application.xml
+++ b/daq2Control/config_fragments/BU/evb/BU_application.xml
@@ -2,9 +2,16 @@
 	<properties xmlns="urn:xdaq-application:evb::BU" xsi:type="soapenc:Struct">
 		<dropEventData xsi:type="xsd:boolean">true</dropEventData>
 		<maxEvtsUnderConstruction xsi:type="xsd:unsignedInt">640</maxEvtsUnderConstruction>
-		<eventsPerRequest xsi:type="xsd:unsignedInt">64</eventsPerRequest>
-		<lumiSectionTimeout xsi:type="xsd:unsignedInt">0</lumiSectionTimeout>
+		<eventsPerRequest xsi:type="xsd:unsignedInt">32</eventsPerRequest>
+		<lumiSectionTimeout xsi:type="xsd:unsignedInt">30</lumiSectionTimeout>
 		<numberOfBuilders xsi:type="xsd:unsignedInt">5</numberOfBuilders>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
+		<rawDataDir xsi:type="xsd:string">/fff/ramdisk</rawDataDir>
+		<metaDataDir xsi:type="xsd:string">/fff/ramdisk</metaDataDir>
+		<maxEventsPerFile xsi:type="xsd:unsignedInt">400</maxEventsPerFile>
+		<rawDataHighWaterMark xsi:type="xsd:double">0.95</rawDataHighWaterMark>
+		<rawDataLowWaterMark xsi:type="xsd:double">0.75</rawDataLowWaterMark>
+		<calculateAdler32 xsi:type="xsd:boolean">true</calculateAdler32>
+		<resourcesPerCore xsi:type="xsd:double">0.2</resourcesPerCore>
 	</properties>
 </xc:Application>

--- a/daq2Control/config_fragments/BU/evb/BU_policy_ibv.xml
+++ b/daq2Control/config_fragments/BU/evb/BU_policy_ibv.xml
@@ -1,24 +1,25 @@
 <pol:policy xmlns:pol="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor-(.+)/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="10" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1"  affinity="12" />
-	<pol:element pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="8" />
-	<pol:element pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_0/waiting" type="thread" package="numa" mempolicy="local" affinity="9" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_1/waiting" type="thread" package="numa" mempolicy="local" affinity="14" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_2/waiting" type="thread" package="numa" mempolicy="local" affinity="15" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_3/waiting" type="thread" package="numa" mempolicy="local" affinity="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_4/waiting" type="thread" package="numa" mempolicy="local" affinity="3" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_5/waiting" type="thread" package="numa" mempolicy="local" affinity="5" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/requestFragments/waiting" type="thread" package="numa" mempolicy="local" affinity="13" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/fileMover/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/lumiAccounting/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
-	<pol:element pattern="urn:superFragmentFIFO(.+)" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:fileStatisticsFIFO_stream(.+):alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:freeResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
-	<pol:element pattern="urn:blockedResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_0/waiting" type="thread" package="numa" mempolicy="local" affinity="9" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_1/waiting" type="thread" package="numa" mempolicy="local" affinity="14" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_2/waiting" type="thread" package="numa" mempolicy="local" affinity="15" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_3/waiting" type="thread" package="numa" mempolicy="local" affinity="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_4/waiting" type="thread" package="numa" mempolicy="local" affinity="3" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/Builder_5/waiting" type="thread" package="numa" mempolicy="local" affinity="5" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/requestFragments/waiting" type="thread" package="numa" mempolicy="local" affinity="13" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/fileMover/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/lumiAccounting/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:superFragmentFIFO(.+)" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:fileStatisticsFIFO_stream(.+):alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:freeResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:blockedResourceFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor-(.+)/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:http-(.+)/waiting" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="10" />
+      <pol:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="12" />
+      <pol:element pattern="urn:toolbox-mem-allocator:CommittedHeapAllocator" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:toolbox-mem-allocator-ibv-receiver(.*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:toolbox-mem-allocator-ibv-sender(.*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <pol:element pattern="urn:undefined:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
 </pol:policy>

--- a/daq2Control/config_fragments/RU/evb/RU_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application.xml
@@ -6,8 +6,8 @@
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
 		<numberOfResponders xsi:type="xsd:unsignedInt">4</numberOfResponders>
-		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">512</fragmentFIFOCapacity>
-                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">640</fragmentRequestFIFOCapacity>
+		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">256</fragmentFIFOCapacity>
+		<fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1500</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_application_EVM.xml
@@ -2,14 +2,15 @@
 	<properties xmlns="urn:xdaq-application:evb::EVM" xsi:type="soapenc:Struct">
 		<inputSource xsi:type="xsd:string">FEROL</inputSource>
 		<dropInputData xsi:type="xsd:boolean">false</dropInputData>
+                <fakeLumiSectionDuration xsi:type="xsd:unsignedInt">23</fakeLumiSectionDuration>
 		<blockSize xsi:type="xsd:unsignedInt">8192</blockSize>
 		<checkCRC xsi:type="xsd:unsignedInt">0</checkCRC>
 		<computeCRC xsi:type="xsd:boolean">false</computeCRC>
 		<numberOfResponders xsi:type="xsd:unsignedInt">2</numberOfResponders>
 		<numberOfAllocators xsi:type="xsd:unsignedInt">2</numberOfAllocators>
 		<maxTriggerRate xsi:type="xsd:unsignedInt">0</maxTriggerRate>
-		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">512</fragmentFIFOCapacity>
-                <fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">640</fragmentRequestFIFOCapacity>
+		<fragmentFIFOCapacity xsi:type="xsd:unsignedInt">256</fragmentFIFOCapacity>
+		<fragmentRequestFIFOCapacity xsi:type="xsd:unsignedInt">1500</fragmentRequestFIFOCapacity>
 		<fedSourceIds soapenc:arrayType="xsd:ur-type[%d]" xsi:type="soapenc:Array">
 			<item soapenc:position="[0]" xsi:type="xsd:unsignedInt">0</item>
 		</fedSourceIds>

--- a/daq2Control/config_fragments/RU/evb/RU_context.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_context.xml
@@ -17,18 +17,18 @@
 			<autoConnect xsi:type="xsd:boolean">false</autoConnect>
 			<!-- Copy worker configuration -->
 			<i2oFragmentBlockSize xsi:type="xsd:unsignedInt">262144</i2oFragmentBlockSize>
-			<i2oFragmentsNo xsi:type="xsd:unsignedInt">512</i2oFragmentsNo>
+			<i2oFragmentsNo xsi:type="xsd:unsignedInt">256</i2oFragmentsNo>
 			<i2oFragmentPoolSize xsi:type="xsd:unsignedInt">320000000</i2oFragmentPoolSize>
 			<copyWorkerQueueSize xsi:type="xsd:unsignedInt">16</copyWorkerQueueSize>
 			<copyWorkersNo xsi:type="xsd:unsignedInt">4</copyWorkersNo>
 			<doSuperFragment xsi:type="xsd:boolean">false</doSuperFragment>
 			<!-- Input configuration e.g. PSP -->
-			<inputStreamPoolSize xsi:type="xsd:double">2800000</inputStreamPoolSize>
+			<inputStreamPoolSize xsi:type="xsd:double">1400000</inputStreamPoolSize>
 			<maxClients xsi:type="xsd:unsignedInt">64</maxClients>
 			<ioQueueSize xsi:type="xsd:unsignedInt">64</ioQueueSize>
 			<eventQueueSize xsi:type="xsd:unsignedInt">256</eventQueueSize>
 			<maxInputReceiveBuffers xsi:type="xsd:unsignedInt">8</maxInputReceiveBuffers>
-			<maxInputBlockSize xsi:type="xsd:unsignedInt">262144</maxInputBlockSize>
+			<maxInputBlockSize xsi:type="xsd:unsignedInt">131072</maxInputBlockSize>
 		</properties>
 	</xc:Application>
 	<xc:Module>$XDAQ_ROOT/lib/libtcpla.so</xc:Module>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application.xml
@@ -4,12 +4,13 @@
 		<sendPoolName xsi:type="xsd:string">sudapl</sendPoolName>
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
 		<receiverPoolSize xsi:type="xsd:unsignedLong">0x4000000</receiverPoolSize>
-		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
+		<senderPoolSize xsi:type="xsd:unsignedLong">0x200000000</senderPoolSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">32768</completionQueueSize>
 		<sendQueuePairSize xsi:type="xsd:unsignedInt">512</sendQueuePairSize>
 		<recvQueuePairSize xsi:type="xsd:unsignedInt">256</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">131072</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
+		<memAllocTimeout xsi:type="xsd:string">PT1S</memAllocTimeout>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>

--- a/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_ibv_application_EVM.xml
@@ -5,11 +5,12 @@
 		<recvPoolName xsi:type="xsd:string">rudapl</recvPoolName>
 		<receiverPoolSize xsi:type="xsd:unsignedLong">0x40000000</receiverPoolSize>
 		<senderPoolSize xsi:type="xsd:unsignedLong">0x80000000</senderPoolSize>
-		<completionQueueSize xsi:type="xsd:unsignedInt">16384</completionQueueSize>
-		<sendQueuePairSize xsi:type="xsd:unsignedInt">256</sendQueuePairSize>
+		<completionQueueSize xsi:type="xsd:unsignedInt">32768</completionQueueSize>
+		<sendQueuePairSize xsi:type="xsd:unsignedInt">512</sendQueuePairSize>
 		<recvQueuePairSize xsi:type="xsd:unsignedInt">256</recvQueuePairSize>
 		<maxMessageSize xsi:type="xsd:unsignedInt">8192</maxMessageSize>
 		<deviceMTU xsi:type="xsd:unsignedInt">4096</deviceMTU>
+		<memAllocTimeout xsi:type="xsd:string">PT1S</memAllocTimeout>
 		<sendWithTimeout xsi:type="xsd:boolean">true</sendWithTimeout>
 		<useRelay xsi:type="xsd:boolean">false</useRelay>
 	</properties>

--- a/daq2Control/config_fragments/RU/evb/RU_policy_ibv.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_policy_ibv.xml
@@ -1,35 +1,36 @@
     <ns1:policy xmlns:ns1="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
-      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread"/>
-      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" type="thread"/>
-      <ns1:element affinity="2" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread"/>
-      <ns1:element affinity="6" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc"/>
-      <ns1:element affinity="0" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread"/>
-      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc"/>
-      <ns1:element affinity="9" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:RU%d_FRL_PORT/polling" type="thread"/>
-      <ns1:element affinity="13" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:60600/polling" type="thread"/>
-      <ns1:element affinity="14" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-0" type="thread"/>
-      <ns1:element affinity="12" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-1" type="thread"/>
-      <ns1:element affinity="30" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-2" type="thread"/>
-      <ns1:element affinity="28" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-3" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:tcpla-PublicServicePoint-rlist/RU%d_FRL_HOST_NAME" type="alloc"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-acceptor-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-connector-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-ia(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-receiver-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-sender-dispatcher(.+)" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-fragment" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-socket" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-CopyWorker-rlist" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-MemoryCache-rlist" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:squeue:alloc" type="alloc"/>
-      <ns1:element affinity="8" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_0/waiting" type="thread"/>
-      <ns1:element affinity="20" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread"/>
-      <ns1:element affinity="10" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread"/>
-      <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread"/>
-      <ns1:element cpunodes="0" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentFIFO_FED(.+)" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentRequestFIFO:alloc" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:undefined:alloc" type="alloc"/>
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:http-(.+)/waiting" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="2" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="6" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-ibv-receiver(.+*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-ibv-sender(.*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-mem-allocator:CommittedHeapAllocator" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:undefined:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_0/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="8" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="24" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="10" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="26" />
+      <ns1:element pattern="urn:fragmentFIFO_FED(.+)" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:fragmentRequestFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-psp/dvru-c2f33-31-01.dvfbs2v0.cms:60500/polling" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="9" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-psp/dvru-c2f33-31-01.dvfbs2v0.cms:60600/polling" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="13" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-acceptor-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-connector-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-ia(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-receiver-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-sender-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-0" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="14" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-1" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="12" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-2" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="30" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-3" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="28" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-i2o" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-fragment" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-socket" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:tcpla-PublicServicePoint-rlist/dvru-c2f33-31-01.dvfbs2v0.cms" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:tcpla-PublicServicePoint-rlist/60600" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:pt-frl-CopyWorker-rlist" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:pt-frl-MemoryCache-rlist" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:squeue:alloc" type="alloc" package="numa" mempolicy="onnode" node="0" />
     </ns1:policy>

--- a/daq2Control/config_fragments/RU/evb/RU_policy_ibv_EVM.xml
+++ b/daq2Control/config_fragments/RU/evb/RU_policy_ibv_EVM.xml
@@ -1,39 +1,39 @@
     <ns1:policy xmlns:ns1="http://xdaq.web.cern.ch/xdaq/xsd/2013/XDAQPolicy-10">
-      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread"/>
-      <ns1:element cpunodes="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" type="thread"/>
-      <ns1:element affinity="2" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread"/>
-      <ns1:element affinity="6" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-ibv-sender-mlx4_0:ibvla" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:toolbox-mem-allocator-ibv-receiver-(.+)-mlx4_0:ibvla" type="alloc"/>
-      <ns1:element affinity="0" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt::ibv::relayworkloop" type="thread"/>
-      <ns1:element mempolicy="onnode" node="1" package="numa" pattern="urn:pt-ibv-rlist-relayqueue:alloc" type="alloc"/>
-      <ns1:element affinity="9" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:RU%d_FRL_PORT/polling" type="thread"/>
-      <ns1:element affinity="13" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-psp/RU%d_FRL_HOST_NAME:60600/polling" type="thread"/>
-      <ns1:element affinity="14" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-0" type="thread"/>
-      <ns1:element affinity="12" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-1" type="thread"/>
-      <ns1:element affinity="30" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-2" type="thread"/>
-      <ns1:element affinity="28" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-3" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:tcpla-PublicServicePoint-rlist/RU%d_FRL_HOST_NAME" type="alloc"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-acceptor-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-connector-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-ia(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-receiver-dispatcher(.+)" type="thread"/>
-      <ns1:element affinity="1" memnode="1" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:tcpla-sender-dispatcher(.+)" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-fragment" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:toolbox-mem-allocator-frl-socket" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-CopyWorker-rlist" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:pt-frl-MemoryCache-rlist" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:squeue:alloc" type="alloc"/>
-      <ns1:element affinity="8" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_0/waiting" type="thread"/>
-      <ns1:element affinity="20" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread"/>
-      <ns1:element affinity="10" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread"/>
-      <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread"/>
-      <ns1:element affinity="26" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_0/waiting" type="thread"/>
-      <ns1:element affinity="28" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_1/waiting" type="thread"/>
-      <ns1:element affinity="30" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_2/waiting" type="thread"/>
-      <ns1:element cpunodes="0" memnode="0" mempolicy="onnode" package="numa" pattern="urn:toolbox-task-workloop:evb::(.+)/monitoring/waiting" type="thread"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentFIFO_FED(.+)" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:fragmentRequestFIFO:alloc" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:allocateFIFO(.+):alloc" type="alloc"/>
-      <ns1:element mempolicy="onnode" node="0" package="numa" pattern="urn:undefined:alloc" type="alloc"/>
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::acceptor(.*)/waiting" type="thread" package="numa" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::eventworkloop/polling" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:http-(.+)/waiting" package="numa" type="thread" mempolicy="onnode" memnode="1" cpunodes="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloopr(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="2" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt::ibv::completionworkloops(.*)/polling" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="6" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-ibv-receiver(.+*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-ibv-sender(.*)-mlx4_0:ibvla" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-mem-allocator:CommittedHeapAllocator" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:undefined:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_0/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="8" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_1/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="24" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_2/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="10" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Responder_3/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="26" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_0/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="18" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_1/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="22" />
+      <ns1:element pattern="urn:toolbox-task-workloop:evb::(.+)/Allocator_2/waiting" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="28" />
+      <ns1:element pattern="urn:fragmentFIFO_FED(.+)" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:fragmentRequestFIFO:alloc" type="alloc" package="numa" mempolicy="onnode" node="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-psp/dvru-c2f33-27-01.dvfbs2v0.cms:60500/polling" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="9" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-psp/dvru-c2f33-27-01.dvfbs2v0.cms:60600/polling" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="13" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-acceptor-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-connector-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-ia(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-receiver-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:tcpla-sender-dispatcher(.+)" type="thread" package="numa" mempolicy="onnode" memnode="1" affinity="1" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-0" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="14" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-1" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="12" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-2" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="30" />
+      <ns1:element pattern="urn:toolbox-task-workloop:pt-frl-CopyWorker-1-3" type="thread" package="numa" mempolicy="onnode" memnode="0" affinity="28" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-i2o" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-fragment" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:toolbox-mem-allocator-frl-socket" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:tcpla-PublicServicePoint-rlist/dvru-c2f33-27-01.dvfbs2v0.cms" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:tcpla-PublicServicePoint-rlist/60600" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:pt-frl-CopyWorker-rlist" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:pt-frl-MemoryCache-rlist" type="alloc" package="numa" mempolicy="onnode" node="0" />
+      <ns1:element pattern="urn:squeue:alloc" type="alloc" package="numa" mempolicy="onnode" node="0" />
     </ns1:policy>

--- a/daq2Control/daq2Configurator.py
+++ b/daq2Control/daq2Configurator.py
@@ -998,16 +998,20 @@ class daq2Configurator(object):
 		subprocess.call(['mv', '-f', destination+'temp', destination])
 
 	def makeConfig(self, nferols=8, streams_per_ferol=2, nrus=1, nbus=2,
-		           destination='configuration.template.xml'):
+		           destination='configuration.template.xml', separateEVM=False):
 		self.nrus              = nrus
 		self.nbus              = nbus
 		self.nferols           = nferols
 		self.streams_per_ferol = streams_per_ferol
+		if separateEVM:
+			self.nferols += 1
+			self.nrus += 1
 
 		self.FEDConfig = daq2FEDConfiguration(
 			                 nstreams=nferols*streams_per_ferol,
-			                 nfrls=nferols, nrus=nrus,
-			                 ferolRack=self.ferolRack, verbose=self.verbose)
+			                 nfrls=self.nferols, nrus=self.nrus,
+			                 ferolRack=self.ferolRack, verbose=self.verbose,
+			                 separateEVM=separateEVM)
 
 		##
 		self.makeSkeleton()

--- a/daq2Control/daq2Control.py
+++ b/daq2Control/daq2Control.py
@@ -690,7 +690,7 @@ class daq2Control(object):
 			configfilelist.append(filename)
 
 		if not self.splitConfig:
-			if not utils.sendToHostListInParallel(
+			if not utils.sendToHostListInParallel2(
 				          self.config.hosts,
 	                      utils.sendCmdFileToExecutivePacked,
 				          (self._runDir+'/configure.cmd.xml',

--- a/daq2Control/makeDAQ2Config.py
+++ b/daq2Control/makeDAQ2Config.py
@@ -66,6 +66,10 @@ def addConfiguratorOptions(parser):
 		              type='int', dest="ferolRack",
 		              help=("Which ferol rack to use (1,2, or 3) [default: "
 		              	    "%default]. Choose 0 to use all three racks."))
+	parser.add_option("--separateEVM", default=False, action="store_true",
+		              dest="separateEVM",
+		              help=("Use a dedicated EVM with only one input [default: "
+		              	    "%default]"))
 
 	workingdir = os.path.dirname(os.path.realpath(__file__))
 	default_fragdir = os.path.join(workingdir,'config_fragments')
@@ -177,7 +181,7 @@ def main(options, args):
 		elif ext == '':
 			output = os.path.join(name, output)
 
-	configurator.makeConfig(nferols,strperfrl,nrus,nbus,output)
+	configurator.makeConfig(nferols,strperfrl,nrus,nbus,output,options.separateEVM)
 
 	return True
 
@@ -205,4 +209,3 @@ if __name__ == "__main__":
 
 	parser.print_help()
 	exit(-1)
-


### PR DESCRIPTION
Hi Ben,

I added an option to makeDAQ2Config.py called '--separateEVM' which creates a configuration in which the EVM gets only one input. I also updated the configuration parameters to match those used in production.

Remi
