### PR TITLE
Add a 3rd canonical option 

### DIFF
--- a/daq2Control/makeDAQ2ProdConfig.py
+++ b/daq2Control/makeDAQ2ProdConfig.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 		               action="store", type="int", dest="canonical",
 		               help=("Only use exact numbers of FRLs "
 		               	     "0 is non canonical, 1 is 8 streams per RU, "
-		               	     "2 is 16 streams per RU."
+		               	     "2 is 16 streams per RU, 3 is 8 streams with the same RUs as in 2."
 		               	     "[default: non canonical]"))
 	parser.add_option("-d", "--dry", default=False,
 		               action="store_true", dest="dry",


### PR DESCRIPTION
Option (1) is now back to the original behavior: it takes any RU which has at least 8 FEROLs attached and creates a configuration with exactly 8 streams. The new option (3) uses the same RUs as option (2), i.e. which have at least 16 FEROLs, but only uses 8 streams. I.e. option (3) uses the same h/w as option (2).

In addition, assure that the EVM is always the first RU with index 0, regardless on which switch it sits.
