### PR TITLE
Add option to use half the fragment size for those FEROLs with 2 streams

### DIFF
--- a/daq2Control/daq2Control.py
+++ b/daq2Control/daq2Control.py
@@ -276,7 +276,7 @@ class daq2Control(object):
 		if self.options.verbose > 0: print separator
 
 		## Flat profile (i.e. each stream has the same size)
-		if self.options.sizeProfile == 'flat':
+		if self.options.sizeProfile in ['flat','streams']:
 			delay = utils.getFerolDelay(fragSize, rate)
 
 			## Max rate when running with GTPe?
@@ -302,15 +302,20 @@ class daq2Control(object):
 						           dry=self.options.dry)
 					continue
 
+				if self.options.sizeProfile == 'streams' and frl.enableStream0 and frl.enableStream1:
+					divider = 2
+				else:
+					divider = 1
+
 				if frl.enableStream0:
 					utils.setParam(frl, 'ferol::FerolController',
 						           'Event_Length_bytes_FED0',
-						           'unsignedInt', int(fragSize),
+						           'unsignedInt', int(fragSize)/divider,
 						           verbose=self.options.verbose,
 						           dry=self.options.dry)
 					utils.setParam(frl, 'ferol::FerolController',
 						           'Event_Length_Stdev_bytes_FED0',
-						           'unsignedInt', int(fragSizeRMS),
+						           'unsignedInt', int(fragSizeRMS)/divider,
 						           verbose=self.options.verbose,
 						           dry=self.options.dry)
 					utils.setParam(frl, 'ferol::FerolController',
@@ -321,12 +326,12 @@ class daq2Control(object):
 				if frl.enableStream1:
 					utils.setParam(frl, 'ferol::FerolController',
 						           'Event_Length_bytes_FED1',
-						           'unsignedInt', int(fragSize),
+						           'unsignedInt', int(fragSize)/divider,
 						           verbose=self.options.verbose,
 						           dry=self.options.dry)
 					utils.setParam(frl, 'ferol::FerolController',
 						           'Event_Length_Stdev_bytes_FED1',
-						           'unsignedInt', int(fragSizeRMS),
+						           'unsignedInt', int(fragSizeRMS)/divider,
 						           verbose=self.options.verbose,
 						           dry=self.options.dry)
 					utils.setParam(frl, 'ferol::FerolController',

--- a/daq2Control/runDAQ2Test.py
+++ b/daq2Control/runDAQ2Test.py
@@ -90,7 +90,7 @@ def addOptions(parser):
 	parser.add_option("--sizeProfile", default='flat',action="store",
 					  type='string', dest="sizeProfile",
 		              help=("Use different sizes for different streams, can"
-		                    "be either 'flat', 'spike', 'sawtooth', "
+		                    "be either 'flat', 'streams', 'spike', 'sawtooth', "
 		                    "'doublespike', or 'file'. In case of 'file' the"
 		                    " sizes are taken from a file that is a comma-"
 		                    "separated list of fedID,size,sigma,... The "
@@ -369,4 +369,3 @@ if __name__ == "__main__":
 
 	parser.print_help()
 	exit(-1)
-


### PR DESCRIPTION
Add a new option 'streams' to the sizeProfile. If it is enabled, the fragment size is halved for those FEROLs where both streams are active.
